### PR TITLE
Filter channel list case-insensitively

### DIFF
--- a/components/select.js
+++ b/components/select.js
@@ -22,7 +22,7 @@ export default class Select extends React.Component {
         ref="input"
         type="text"
         value={state.filter}
-        onChange={(ev) => this.setState({filter: ev.target.value})}
+        onChange={(ev) => this.setState({filter: ev.target.value.toLowerCase()})}
         onKeyDown={ev => this.handleKeyDown(ev)}
         onFocus={() => this.setState({focused: true})}
         onBlur={() => this.setState({focused: false, blurred: this.n++})}


### PR DESCRIPTION
Mobile browsers default to a "shifted" keyboard when you focus a text field. With case-sensitive filtering you have to remember to un-shift, or the suggestion list will always be empty. 

There's also an `autocapitalize="none"` attribute that would mostly fix the problem, but I don't think it's supported in mobile Firefox.